### PR TITLE
✨ get from stdin if no name provided

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ version = "0.1.0"
 
 [dependencies]
 clap = "2.32"
+atty = "0.2"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Inspired by an excellent tool of the same name: [emoji-fzf](https://github.com/n
 
 ## Usage
 
-```
+```plaintext
 emoji-fzf 0.1.0
 Matt Vertescher <mvertescher@gmail.com>
 An emoji fuzzy finder!
@@ -25,6 +25,13 @@ FLAGS:
 SUBCOMMANDS:
     get     Get unicode emoji given a name
     help    Prints this message or the help of the given subcommand(s)
+```
+
+Or the alias form integrated with fzf (include in your shell rc), and piping
+the result to xclip:
+
+```bash
+alias emoj="emoji-fzf preview | fzf --preview 'emoji-fzf get {1}' | cut -d \" \" -f 1 | emoji-fzf get | xclip"
 ```
 
 ## License

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,8 @@ fn main() {
 fn display_emoji(name: &str) {
     for emoji in emojis::EMOJIS {
         if name == emoji.0 {
-            println!("{}", emoji.1);
+            // Output without trailing newline
+            print!("{}", emoji.1);
             std::process::exit(0);
         }
     }


### PR DESCRIPTION
Support reading from stdin, which is useful when integrating with
scripts for fetching emojis by name.

Also add a note about fzf integration (upstream doesn't have the changes
for using skim preview interactively, so for now use fzf integration via
shell alias).